### PR TITLE
Feat: prevent page scrolling on mouse wheel

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ All configuration options are optional. The options referencing inner coordinate
 | valueArchClass | 'text-[#53d769]' | CSS class for the value arch. |
 | tickClass | 'text-black' | CSS class for the tick line. |
 | valueTextClass | 'text-gray-50 text-[30px] font-normal font-mono' | CSS class for the value text. |
-
+| passiveEvents | false | When set, propagation of handeled events is not prevented. |
 
 **Note** that if you're using Tailwind CSS with automatic purge, you'll probably want to add the default classes as options so PurgeCSS catches them (or you can just whitelist them):
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -35,6 +35,12 @@ const vmodel = ref(0)
       <div class="px-8">
         <ControlKnob id="knob2" v-model="vmodel" :options="options" />
       </div>
+
+      <h2 class="mb-6 text-xl font-semibold">Control Knob with passive event handling (not preventing scrolling)</h2>
+
+      <div class="px-8">
+        <ControlKnob id="knob1" v-model="vmodel" :options="{ passiveEvents: true }" />
+      </div>
     </div>
     <div v-if="false">
       <h2 class="mb-6 text-3xl font-semibold">Knob Designer</h2>

--- a/src/ControlKnob.vue
+++ b/src/ControlKnob.vue
@@ -81,7 +81,8 @@ const valueArchClass = props.options?.valueArchClass || 'text-[#53d769]'
 const tickClass = props.options?.tickClass || 'text-black'
 const valueTextClass =
   props.options?.valueTextClass || 'text-gray-50 text-[30px] font-normal font-mono'
-const passiveEvents = props.options?.passiveEvents === undefined ? false : props.options?.passiveEvents
+const passiveEvents =
+  props.options?.passiveEvents === undefined ? false : props.options?.passiveEvents
 
 const startValue = vModel.value
 
@@ -132,7 +133,7 @@ const downListener = (event: MouseEvent) => {
   mouseIsDown.value = true
   mouseMoved.value = false
   prevY = event.clientY
-  preventScrolling(event);
+  preventScrolling(event)
 }
 
 function moveListener(event: MouseEvent) {
@@ -175,9 +176,9 @@ const debouncedMoveListener = leadingDebounce(moveListener)
  * @remarks If set, keeps page from scrolling while handling the knob
  */
 function preventScrolling(event: TouchEvent | MouseEvent | KeyboardEvent): void {
-  if (passiveEvents === false) {    
-    event.preventDefault();
-    event.stopPropagation(); 
+  if (passiveEvents === false) {
+    event.preventDefault()
+    event.stopPropagation()
   }
 }
 
@@ -213,11 +214,8 @@ function keyDownListener(event: KeyboardEvent) {
     shiftModifier.value = true
   }
 
-  if (
-    hasFocus.value &&
-    (event.key === 'ArrowUp' || event.key === 'ArrowDown')
-  ) {
-    preventScrolling(event);  
+  if (hasFocus.value && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+    preventScrolling(event)
   }
 }
 
@@ -251,7 +249,7 @@ function wheelListener(event: WheelEvent) {
     newValue = controlAngle.value - 1 * wheelModifier
   }
   changeValue(newValue)
-  preventScrolling(event);
+  preventScrolling(event)
 }
 
 function mouseOverHandler() {
@@ -268,7 +266,7 @@ watch(
     if (element && !oldElement) {
       element.addEventListener('mousedown', downListener)
       // Note: The wheel event is handeled according to the option, possibly manipulating scrolling behaviour
-      element.addEventListener('wheel', wheelListener, { passive: passiveEvents } )
+      element.addEventListener('wheel', wheelListener, { passive: passiveEvents })
       element.addEventListener('mouseenter', mouseOverHandler)
       element.addEventListener('mouseleave', mouseOutHandler)
       document.addEventListener('mouseup', upListener)

--- a/src/ControlKnob.vue
+++ b/src/ControlKnob.vue
@@ -265,7 +265,6 @@ watch(
   (element, oldElement) => {
     if (element && !oldElement) {
       element.addEventListener('mousedown', downListener)
-      // Note: The wheel event is handeled according to the option, possibly manipulating scrolling behaviour
       element.addEventListener('wheel', wheelListener, { passive: passiveEvents })
       element.addEventListener('mouseenter', mouseOverHandler)
       element.addEventListener('mouseleave', mouseOutHandler)

--- a/src/ControlKnob.vue
+++ b/src/ControlKnob.vue
@@ -263,7 +263,8 @@ watch(
   (element, oldElement) => {
     if (element && !oldElement) {
       element.addEventListener('mousedown', downListener)
-      element.addEventListener('wheel', wheelListener)
+      // Note: The wheel event is actually non-passive, since it does manipulate scrolling behaviour
+      element.addEventListener('wheel', wheelListener, { passive: false } )
       element.addEventListener('mouseenter', mouseOverHandler)
       element.addEventListener('mouseleave', mouseOutHandler)
       document.addEventListener('mouseup', upListener)

--- a/src/ControlKnob.vue
+++ b/src/ControlKnob.vue
@@ -130,6 +130,7 @@ const downListener = (event: MouseEvent) => {
   mouseIsDown.value = true
   mouseMoved.value = false
   prevY = event.clientY
+  preventScrolling(event);
 }
 
 function moveListener(event: MouseEvent) {
@@ -168,6 +169,14 @@ function moveListener(event: MouseEvent) {
 
 const debouncedMoveListener = leadingDebounce(moveListener)
 
+/** Prevents propagation of the event
+ * @remarks Prevents page scrolling while handling the knob
+ */
+function preventScrolling(event: TouchEvent | MouseEvent | KeyboardEvent): void {
+  event.preventDefault();
+  event.stopPropagation(); 
+}
+
 const upListener = () => {
   mouseIsDown.value = false
 }
@@ -202,10 +211,9 @@ function keyDownListener(event: KeyboardEvent) {
 
   if (
     hasFocus.value &&
-    shiftModifier.value &&
     (event.key === 'ArrowUp' || event.key === 'ArrowDown')
   ) {
-    event.preventDefault()
+    preventScrolling(event);  
   }
 }
 
@@ -239,6 +247,7 @@ function wheelListener(event: WheelEvent) {
     newValue = controlAngle.value - 1 * wheelModifier
   }
   changeValue(newValue)
+  preventScrolling(event);
 }
 
 function mouseOverHandler() {

--- a/src/ControlKnob.vue
+++ b/src/ControlKnob.vue
@@ -39,6 +39,7 @@ interface Props {
     valueArchClass?: string
     tickClass?: string
     valueTextClass?: string
+    passiveEvents?: boolean
   }
 }
 
@@ -80,6 +81,7 @@ const valueArchClass = props.options?.valueArchClass || 'text-[#53d769]'
 const tickClass = props.options?.tickClass || 'text-black'
 const valueTextClass =
   props.options?.valueTextClass || 'text-gray-50 text-[30px] font-normal font-mono'
+const passiveEvents = props.options?.passiveEvents === undefined ? false : props.options?.passiveEvents
 
 const startValue = vModel.value
 
@@ -169,12 +171,14 @@ function moveListener(event: MouseEvent) {
 
 const debouncedMoveListener = leadingDebounce(moveListener)
 
-/** Prevents propagation of the event
- * @remarks Prevents page scrolling while handling the knob
+/** According to the chosen option, prevents propagation of the event.
+ * @remarks If set, keeps page from scrolling while handling the knob
  */
 function preventScrolling(event: TouchEvent | MouseEvent | KeyboardEvent): void {
-  event.preventDefault();
-  event.stopPropagation(); 
+  if (passiveEvents === false) {    
+    event.preventDefault();
+    event.stopPropagation(); 
+  }
 }
 
 const upListener = () => {
@@ -263,8 +267,8 @@ watch(
   (element, oldElement) => {
     if (element && !oldElement) {
       element.addEventListener('mousedown', downListener)
-      // Note: The wheel event is actually non-passive, since it does manipulate scrolling behaviour
-      element.addEventListener('wheel', wheelListener, { passive: false } )
+      // Note: The wheel event is handeled according to the option, possibly manipulating scrolling behaviour
+      element.addEventListener('wheel', wheelListener, { passive: passiveEvents } )
       element.addEventListener('mouseenter', mouseOverHandler)
       element.addEventListener('mouseleave', mouseOutHandler)
       document.addEventListener('mouseup', upListener)

--- a/tests/e2e/integration/scroll_spec.ts
+++ b/tests/e2e/integration/scroll_spec.ts
@@ -1,18 +1,88 @@
-// https://docs.cypress.io/api/introduction/api.html
-
 describe('Homepage', () => {
+  /** Asserts the page scrolling behaviour with mouse wheel events
+   * @remarks This test is quite challenging, since the mouse
+   * wheel event should be triggered on the document, not on a specific
+   * element, to be most faithful to real circumstances.
+   * However, with Google Chrome at least, this test is misleading,
+   * since the cypress events never cause 
+   * page scrolling in the first place.
+   */
   it('does not scroll when using the mouse wheel', () => {
     // arrange (on a deliberately short viewport)
-    cy.viewport(1024, 200)
-    cy.visit('/')
+    cy.viewport(1024, 200);
+    cy.visit('/');
 
     // act
-    cy.get('#knob2').invoke('show').click()
     Cypress._.times(15, (k) => {
-      cy.get('#knob2').trigger("wheel", { deltaY: -120, bubbles: true})
-    })
+      cy.get('#knob1').trigger('wheel', {
+        deltaY: -120,
+        bubbles: true,
+        scrollBehavior: false,
+      });
+    });
+    Cypress._.times(15, (k) => {
+      cy.get('#knob1').trigger('wheel', {
+        deltaY: 120,
+        bubbles: true,
+        scrollBehavior: false,
+      });
+    });
 
     // assert
-    cy.window().its('scrollY').should('equal', 0)
-  })
-})
+    cy.window().its('scrollY').should('equal', 0);
+  });
+
+  /** Asserts the page scrolling behaviour with keyboard events
+   * @remarks This test is quite challenging.
+   * With Google Chrome at least, this test is misleading,
+   * since the cypress events never cause 
+   * page scrolling in the first place.
+   */
+  it('does not scroll when using the key clicks', () => {
+    // arrange (on a deliberately short viewport)
+    cy.viewport(1024, 200);
+    cy.visit('/');
+
+    // act
+    Cypress._.times(15, (k) => {
+
+      cy.get('#knob1').trigger('keydown', {
+        key: "ArrowUp",
+        code: "ArrowUp",
+        which: 38,
+        scrollBehavior: false,
+      });
+      cy.get('#knob1').trigger('keypress', {
+        key: "ArrowUp",
+        code: "ArrowUp",
+        which: 38,
+        scrollBehavior: false,
+      });
+      cy.get('#knob1').trigger('keyup', {
+        key: "ArrowUp",
+        code: "ArrowUp",
+        which: 38,
+        scrollBehavior: false,
+      });
+
+
+    });
+    Cypress._.times(15, (k) => {
+      cy.get('#knob1').trigger('keydown', {
+        keyCode: 40,
+        scrollBehavior: false,
+      });
+      cy.get('#knob1').trigger('keypress', {
+        keyCode: 40,
+        scrollBehavior: false,
+      });
+      cy.get('#knob1').trigger('keyup', {
+        keyCode: 40,
+        scrollBehavior: false,
+      });
+    });
+
+    // assert
+    cy.window().its('scrollY').should('equal', 0);
+  });
+});

--- a/tests/e2e/integration/scroll_spec.ts
+++ b/tests/e2e/integration/scroll_spec.ts
@@ -1,0 +1,18 @@
+// https://docs.cypress.io/api/introduction/api.html
+
+describe('Homepage', () => {
+  it('does not scroll when using the mouse wheel', () => {
+    // arrange (on a deliberately short viewport)
+    cy.viewport(1024, 200)
+    cy.visit('/')
+
+    // act
+    cy.get('#knob2').invoke('show').click()
+    Cypress._.times(15, (k) => {
+      cy.get('#knob2').trigger("wheel", { deltaY: -120, bubbles: true})
+    })
+
+    // assert
+    cy.window().its('scrollY').should('equal', 0)
+  })
+})


### PR DESCRIPTION
Finally worked through it. 

Please note: I tried to add some cypress tests (a first for me, and I kind of liked it), but I did not manage to have "real" keypresses or mouse wheel events, that actually break things as expected. So, in the current form, they are quite useless. You might want to fix them, if possible, or just remove them.

Best Regards, Marcel

Fixes #8 